### PR TITLE
Source/Target length distinction

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -34,8 +34,10 @@ parser.add_argument('-tgt_vocab',
                     help="Path to an existing target vocabulary")
 
 
-parser.add_argument('-seq_length', type=int, default=50,
-                    help="Maximum sequence length")
+parser.add_argument('-src_seq_length', type=int, default=50,
+                    help="Maximum source sequence length")
+parser.add_argument('-tgt_seq_length', type=int, default=50,
+                    help="Maximum target sequence length")
 parser.add_argument('-shuffle',    type=int, default=1,
                     help="Shuffle data")
 parser.add_argument('-seed',       type=int, default=3435,
@@ -108,7 +110,7 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
                 print('WARNING: source and target do not have the same number of sentences')
             break
 
-        if len(srcWords) <= opt.seq_length and len(tgtWords) <= opt.seq_length:
+        if len(srcWords) <= opt.src_seq_length and len(tgtWords) <= opt.tgt_seq_length:
 
             src += [srcDicts.convertToIdx(srcWords,
                                           onmt.Constants.UNK_WORD)]
@@ -141,8 +143,8 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
     src = [src[idx] for idx in perm]
     tgt = [tgt[idx] for idx in perm]
 
-    print('Prepared %d sentences (%d ignored due to length == 0 or > %d)' %
-          (len(src), ignored, opt.seq_length))
+    print('Prepared %d sentences (%d ignored due to length == 0 or source length > %d or target length > %d)' %
+          (len(src), ignored, opt.src_seq_length, opt.tgt_seq_length))
 
     return src, tgt
 

--- a/train.py
+++ b/train.py
@@ -164,6 +164,7 @@ def trainModel(model, trainData, validData, dataset, optim):
 
         total_loss, report_loss = 0, 0
         total_words, report_words = 0, 0
+        report_src_words = 0
         start = time.time()
         for i in range(len(trainData)):
 
@@ -183,16 +184,17 @@ def trainModel(model, trainData, validData, dataset, optim):
 
             report_loss += loss
             total_loss += loss
+            report_src_words += batch[0].data.ne(onmt.Constants.PAD).sum()
             num_words = targets.data.ne(onmt.Constants.PAD).sum()
             total_words += num_words
             report_words += num_words
             if i % opt.log_interval == 0 and i > 0:
-                print("Epoch %2d, %5d/%5d batches; perplexity: %6.2f; %3.0f tokens/s" %
+                print("Epoch %2d, %5d/%5d batches; perplexity: %6.2f; %3.0f Source tokens/s" %
                       (epoch, i, len(trainData),
                       math.exp(report_loss / report_words),
-                      report_words/(time.time()-start)))
+                      report_src_words/(time.time()-start)))
 
-                report_loss = report_words = 0
+                report_loss = report_words = report_src_words = 0
                 start = time.time()
 
         return total_loss / total_words


### PR DESCRIPTION
## Preprocess parameters
Removed parameter `-seq_length`
New parameters `-src_seq_length` and `-tgt_seq_length`

---

## Training speed token/s
In both LUA/PyTorch OpenNMT, the training process prints a speed, in token/sec, but:

* LUA OpenNMT is printing source token/sec
* PyOpenNMT is printing target token/sec

This can lead to important differences, especially when src/tgt sequence length are different (e.g. summarization), and therefore lead to false conclusion about performances.

See also: [pytoch/example/issue#75](https://github.com/pytorch/examples/issues/75)